### PR TITLE
chore: Update versions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -47,7 +47,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             KANIKO_VERSION=1.19.2
-            ENV_CRED_HELPER_VERSION=1.2.2
+            ENV_CRED_HELPER_VERSION=1.2.4
             ECR_CRED_HELRER_VERSION=0.7.1
             GCR_CRED_HELRER_VERSION=2.1.10
             MANIFEST_TOOL_VERSION=2.0.8

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,7 +50,7 @@ jobs:
             ENV_CRED_HELPER_VERSION=1.2.4
             ECR_CRED_HELRER_VERSION=0.7.1
             GCR_CRED_HELRER_VERSION=2.1.21
-            MANIFEST_TOOL_VERSION=2.0.8
+            MANIFEST_TOOL_VERSION=2.1.5
             SKOPEO_VERSION=1.13.3
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -49,7 +49,7 @@ jobs:
             KANIKO_VERSION=1.19.2
             ENV_CRED_HELPER_VERSION=1.2.4
             ECR_CRED_HELRER_VERSION=0.7.1
-            GCR_CRED_HELRER_VERSION=2.1.10
+            GCR_CRED_HELRER_VERSION=2.1.21
             MANIFEST_TOOL_VERSION=2.0.8
             SKOPEO_VERSION=1.13.3
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -46,7 +46,7 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: |
-            KANIKO_VERSION=1.15.0
+            KANIKO_VERSION=1.19.2
             ENV_CRED_HELPER_VERSION=1.2.2
             ECR_CRED_HELRER_VERSION=0.7.1
             GCR_CRED_HELRER_VERSION=2.1.10

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,8 +50,8 @@ jobs:
             ENV_CRED_HELPER_VERSION=1.2.4
             ECR_CRED_HELRER_VERSION=0.7.1
             GCR_CRED_HELRER_VERSION=2.1.21
-            MANIFEST_TOOL_VERSION=2.1.5
-            SKOPEO_VERSION=1.13.3
+            MANIFEST_TOOL_VERSION=2.1.g
+            SKOPEO_VERSION=1.14.0
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 as kaniko
+FROM alpine:3.19 as kaniko
 
 RUN apk --update --no-cache add skopeo umoci curl
 


### PR DESCRIPTION
No breaking changes found in the changelogs.

- skopeo to 1.14.0
- manifest tool to 2.1.5
- gcr cred helper to 2.1.21
- env cred helper to 1.2.4
- kaniko to 1.19.2
- alpine to 3.19
